### PR TITLE
Add KDF Context validation

### DIFF
--- a/draft-ietf-suit-firmware-encryption-kdf-context.cddl
+++ b/draft-ietf-suit-firmware-encryption-kdf-context.cddl
@@ -1,0 +1,23 @@
+COSE_KDF_Context = [
+    AlgorithmID : int,
+    PartyUInfo : [ PartyInfoSender ],
+    PartyVInfo : [ PartyInfoRecipient ],
+    SuppPubInfo : [
+        keyDataLength : uint,
+        protected : bstr .cbor recipient_header_map_esdh,
+        other: 'SUIT Payload Encryption'
+    ],
+    ? SuppPrivInfo : bstr
+]
+
+PartyInfoSender = (
+    identity : nil,
+    nonce : nil,
+    other : nil
+)
+
+PartyInfoRecipient = (
+    identity : nil,
+    nonce : nil,
+    other : nil
+)

--- a/draft-ietf-suit-firmware-encryption.md
+++ b/draft-ietf-suit-firmware-encryption.md
@@ -699,30 +699,8 @@ the constant string "SUIT Payload Encryption".
 content of the recipient_header_map_esdh field, which contains (among other fields)
 the identifier of the content key distribution method.
 
-~~~
-PartyInfoSender = (
-    identity : nil,
-    nonce : nil,
-    other : nil
-)
-
-PartyInfoRecipient = (
-    identity : nil,
-    nonce : nil,
-    other : nil
-)
-
-COSE_KDF_Context = [
-    AlgorithmID : int,
-    PartyUInfo : [ PartyInfoSender ],
-    PartyVInfo : [ PartyInfoRecipient ],
-    SuppPubInfo : [
-        keyDataLength : uint,
-        protected : bstr .cbor recipient_header_map_esdh,
-        other: bstr "SUIT Payload Encryption"
-    ],
-    SuppPrivInfo : bstr .size 0
-]
+~~~ CDDL
+{::include draft-ietf-suit-firmware-encryption-kdf-context.cddl}
 ~~~
 {: #cddl-context-info title="CDDL for COSE_KDF_Context Structure"}
 

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,3 +1,4 @@
+*.cbor
 *.cose
 *.suit
 *.xml

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,17 +1,22 @@
 SUIT_ENCRYPTION_INFO := suit-encryption-info-aes-kw.cose suit-encryption-info-es-ecdh.cose
 SUIT_MANIFEST_WITH_ENCRYPTED_PAYLOAD := suit-manifest-aes-kw.suit suit-manifest-aes-kw-content.suit suit-manifest-es-ecdh-content.suit suit-manifest-es-ecdh-dependency.suit
+KDF_CONTEXT := a128kw_kdf_context.cbor
+CDDL := draft-ietf-suit-firmware-encryption.cddl draft-ietf-suit-manifest.cddl draft-ietf-suit-firmware-encryption-kdf-context.cddl
 
 .PHONY: all
-all: $(SUIT_ENCRYPTION_INFO) $(SUIT_MANIFEST_WITH_ENCRYPTED_PAYLOAD)
+all: $(SUIT_ENCRYPTION_INFO) $(SUIT_MANIFEST_WITH_ENCRYPTED_PAYLOAD) $(KDF_CONTEXT)
 
 %.cose: %.diag
+	diag2cbor.rb $< > $@
+
+%.cbor: %.diag
 	diag2cbor.rb $< > $@
 
 %.suit: %.diag.signed
 	diag2cbor.rb $< > $@
 
 .PHONY: cddl
-cddl: draft-ietf-suit-firmware-encryption.cddl draft-ietf-suit-manifest.cddl
+cddl: $(CDDL)
 
 draft-ietf-suit-firmware-encryption.cddl: ../draft-ietf-suit-firmware-encryption.cddl rfc-9052.cddl
 	cat $^ > $@
@@ -26,11 +31,15 @@ rfc-9052.cddl: rfc-9052.xml
 rfc-9052.xml:
 	curl https://raw.githubusercontent.com/cose-wg/cose-rfc8152bis/master/draft-ietf-cose-rfc8152bis-struct.xml -o $@
 
+draft-ietf-suit-firmware-encryption-kdf-context.cddl: draft-ietf-suit-firmware-encryption.cddl
+	cat ../$@ $^ > $@
+
 .PHONY: validate
 validate: all cddl
 	cddl draft-ietf-suit-firmware-encryption.cddl validate suit-encryption-info-aes-kw.cose
 	cddl draft-ietf-suit-firmware-encryption.cddl validate suit-encryption-info-es-ecdh.cose
 	cddl draft-ietf-suit-manifest.cddl validate suit-manifest-aes-kw.suit
+	cddl draft-ietf-suit-firmware-encryption-kdf-context.cddl validate a128kw_kdf_context.cbor
 
 .PHONY: clean
 clean:

--- a/examples/a128kw_kdf_context.diag
+++ b/examples/a128kw_kdf_context.diag
@@ -1,0 +1,10 @@
+[
+    / AlgorithmID: / -3 / A128KW /,
+    / PartyUInfo: / [ null, null, null ],
+    / PartyVInfo: / [ null, null, null ],
+    / SuppPubInfo: / [
+        / keyDataLength: / 128,
+        / protected: / << { / alg / 1: -3 / A128KW / } >>,
+        / other: / 'SUIT Payload Encryption'
+    ]
+]


### PR DESCRIPTION
## How To Check This PR
### Validate only KDF Context CBOR binary and CDDL
```
$ cd examples/
$ make a128kw_kdf_context.cbor
$ make draft-ietf-suit-firmware-encryption-kdf-context.cddl
$ cddl draft-ietf-suit-firmware-encryption-kdf-context.cddl validate a128kw_kdf_context.cbor
```

### Including other CBOR binaries and CDDLs
```
$ make -C examples/ validate
```

## NOTE
The CDDL of `COSE_KDF_Context` was split from md file and fixed.

### Fixed other to avoid CDDL grammar error
```
-       other: bstr .cbor "SUIT Payload Encryption"
+       other: 'SUIT Payload Encryption'
```
NOTE: `'SUIT Payload Encryption'` is encoded as this. The content is text but the type is bstr.
```
57                                      # bytes(23)
   53554954205061796C6F616420456E6372797074696F6E # "SUIT Payload Encryption"
```

### Made SuppPrivInfo OPTIONAL
Because the original CDDL of KDF Context in RFC 9053 allows it, and current implementations such as t_cose and python-cwt encode nothing but `bstr .size 0` (`''`).
See [A128KW example](https://github.com/suit-wg/suit-firmware-encryption/pull/36/files#diff-cb85c6e6b561505768b889db1151b7b1c5045905fbc66fa6d5fb725ed899588d).
```
-    SuppPrivInfo : bstr .size 0
+    ? SuppPrivInfo : bstr
```