### PR TITLE
Fix cddl for non AEAD

### DIFF
--- a/draft-ietf-suit-firmware-encryption.cddl
+++ b/draft-ietf-suit-firmware-encryption.cddl
@@ -20,7 +20,7 @@ empty_map = {}
 
 recipient_header_unpr_map_aeskw =
 {
-    1 => int,         ; algorithm identifier for non AEAD
+    1 => int,         ; algorithm identifier for non AEAD cipher
   ? 4 => bstr,        ; identifier of the recipient public key
   * label => values   ; extension point
 }

--- a/draft-ietf-suit-firmware-encryption.cddl
+++ b/draft-ietf-suit-firmware-encryption.cddl
@@ -61,7 +61,7 @@ outer_header_map_protected =
 
 outer_header_map_unprotected =
 {
-  ? 1 => int,         ; algorithm identifier for non AEAD
+  ? 1 => int,         ; algorithm identifier for non AEAD cipher
     5 => bstr,        ; IV
   * label => values   ; extension point
 }

--- a/draft-ietf-suit-firmware-encryption.cddl
+++ b/draft-ietf-suit-firmware-encryption.cddl
@@ -55,7 +55,7 @@ recipient_header_unpr_map_esdh =
 ; common definitions
 outer_header_map_protected =
 {
-  ? 1 => int,         ; algorithm identifier for AEAD
+  ? 1 => int,         ; algorithm identifier for AEAD cipher
   * label => values   ; extension point
 }
 

--- a/draft-ietf-suit-firmware-encryption.cddl
+++ b/draft-ietf-suit-firmware-encryption.cddl
@@ -5,7 +5,7 @@ SUIT_Encryption_Info = #6.96(
     SUIT_Encryption_Info_ESDH .within COSE_Encrypt)
 
 SUIT_Encryption_Info_AESKW = [
-  protected   : bstr .cbor outer_header_map_protected,
+  protected   : bstr .size 0 / bstr .cbor outer_header_map_protected,
   unprotected : outer_header_map_unprotected,
   ciphertext  : bstr / nil,
   recipients  : [ + COSE_recipient_AESKW .within COSE_recipient ]
@@ -26,14 +26,14 @@ recipient_header_unpr_map_aeskw =
 }
 
 SUIT_Encryption_Info_ESDH = [
-  protected   : bstr .cbor outer_header_map_protected,
+  protected   : bstr .size 0 / bstr .cbor outer_header_map_protected,
   unprotected : outer_header_map_unprotected,
   ciphertext  : bstr / nil,
   recipients  : [ + COSE_recipient_ESDH .within COSE_recipient ]
 ]
 
 COSE_recipient_ESDH = [
-  protected   : bstr .cbor recipient_header_map_esdh,
+  protected   : bstr .size 0 / bstr .cbor recipient_header_map_esdh,
   unprotected : recipient_header_unpr_map_esdh,
   ciphertext  : bstr        ; CEK encrypted with KEK
 ]

--- a/draft-ietf-suit-firmware-encryption.cddl
+++ b/draft-ietf-suit-firmware-encryption.cddl
@@ -20,7 +20,7 @@ empty_map = {}
 
 recipient_header_unpr_map_aeskw =
 {
-    1 => int,         ; algorithm identifier
+  ? 1 => int,         ; algorithm identifier for non AEAD
   ? 4 => bstr,        ; identifier of the recipient public key
   * label => values   ; extension point
 }
@@ -40,13 +40,14 @@ COSE_recipient_ESDH = [
 
 recipient_header_map_esdh =
 {
-    1 => int,         ; algorithm identifier
+  ? 1 => int,         ; algorithm identifier for AEAD
   * label => values   ; extension point
 }
 
 recipient_header_unpr_map_esdh =
 {
    -1 => COSE_Key,    ; ephemeral public key for the sender
+  ? 1 => int,         ; algorithm identifier for non AEAD
   ? 4 => bstr,        ; identifier of the recipient public key
   * label => values   ; extension point
 }
@@ -54,12 +55,13 @@ recipient_header_unpr_map_esdh =
 ; common definitions
 outer_header_map_protected =
 {
-    1 => int,         ; algorithm identifier
+  ? 1 => int,         ; algorithm identifier for AEAD
   * label => values   ; extension point
 }
 
 outer_header_map_unprotected =
 {
+  ? 1 => int,         ; algorithm identifier for non AEAD
     5 => bstr,        ; IV
   * label => values   ; extension point
 }

--- a/draft-ietf-suit-firmware-encryption.cddl
+++ b/draft-ietf-suit-firmware-encryption.cddl
@@ -20,7 +20,7 @@ empty_map = {}
 
 recipient_header_unpr_map_aeskw =
 {
-  ? 1 => int,         ; algorithm identifier for non AEAD
+    1 => int,         ; algorithm identifier for non AEAD
   ? 4 => bstr,        ; identifier of the recipient public key
   * label => values   ; extension point
 }

--- a/draft-ietf-suit-firmware-encryption.cddl
+++ b/draft-ietf-suit-firmware-encryption.cddl
@@ -40,7 +40,7 @@ COSE_recipient_ESDH = [
 
 recipient_header_map_esdh =
 {
-  ? 1 => int,         ; algorithm identifier for AEAD
+  ? 1 => int,         ; algorithm identifier for AEAD cipher
   * label => values   ; extension point
 }
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -75,15 +75,19 @@ validate_binary_match: $(SUIT_ENCRYPTION_INFO) $(SUIT_ENCRYPTION_INFO:.cose=.hex
 
 .PHONY: validate_cddl_match
 validate_cddl_match: all cddl
-	cddl draft-ietf-suit-firmware-encryption.cddl validate suit-encryption-info-aes-kw-aes-gcm.cose 2> /dev/null
-	cddl draft-ietf-suit-firmware-encryption.cddl validate suit-encryption-info-es-ecdh-aes-gcm.cose 2> /dev/null
+	RUBYOPT="-W0" cddl draft-ietf-suit-firmware-encryption.cddl validate suit-encryption-info-aes-kw-aes-gcm.cose
+	RUBYOPT="-W0" cddl draft-ietf-suit-firmware-encryption.cddl validate suit-encryption-info-es-ecdh-aes-gcm.cose
+	RUBYOPT="-W0" cddl draft-ietf-suit-firmware-encryption.cddl validate suit-encryption-info-aes-kw-aes-cbc.cose
+	RUBYOPT="-W0" cddl draft-ietf-suit-firmware-encryption.cddl validate suit-encryption-info-es-ecdh-aes-cbc.cose
+	RUBYOPT="-W0" cddl draft-ietf-suit-firmware-encryption.cddl validate suit-encryption-info-aes-kw-aes-ctr.cose
+	RUBYOPT="-W0" cddl draft-ietf-suit-firmware-encryption.cddl validate suit-encryption-info-es-ecdh-aes-ctr.cose
 	@echo [SUCCESS] Each SUIT_Encryption_Info matches to its CDDL
-	cddl draft-ietf-suit-manifest.cddl validate suit-manifest-aes-kw.suit 2> /dev/null
-	cddl draft-ietf-suit-manifest.cddl validate suit-manifest-aes-kw-content.suit 2> /dev/null
-	cddl draft-ietf-suit-manifest.cddl validate suit-manifest-es-ecdh-content.suit 2> /dev/null
-	cddl draft-ietf-suit-manifest.cddl validate suit-manifest-es-ecdh-dependency.suit 2> /dev/null
+	RUBYOPT="-W0" cddl draft-ietf-suit-manifest.cddl validate suit-manifest-aes-kw.suit
+	RUBYOPT="-W0" cddl draft-ietf-suit-manifest.cddl validate suit-manifest-aes-kw-content.suit
+	RUBYOPT="-W0" cddl draft-ietf-suit-manifest.cddl validate suit-manifest-es-ecdh-content.suit
+	RUBYOPT="-W0" cddl draft-ietf-suit-manifest.cddl validate suit-manifest-es-ecdh-dependency.suit
 	@echo [SUCCESS] Each SUIT Manifest with Encrypted Payloads matches to its CDDL
-	cddl draft-ietf-suit-firmware-encryption-kdf-context.cddl validate a128kw_kdf_context.cbor 2> /dev/null
+	RUBYOPT="-W0" cddl draft-ietf-suit-firmware-encryption-kdf-context.cddl validate a128kw_kdf_context.cbor
 	@echo [SUCCESS] KDF Context matches to its CDDL
 
 .PHONY: validate_decrypted_plaintext


### PR DESCRIPTION
- Accept alg (1) in both protected and unprotected header as optional
- Make some protected header accept a zero-length byte string
- Add cddl validation on non AEAD examples
- Suppress warnings such as "*** Unused rule foo" by `RUBYOPT="-W0"`