### PR TITLE
[EDITORIAL] Fix KDF Context in text and scripts

### DIFF
--- a/draft-ietf-suit-firmware-encryption.md
+++ b/draft-ietf-suit-firmware-encryption.md
@@ -750,8 +750,8 @@ This example uses the following parameters:
   - Algorithm ID: 1 (A128GCM)
   - SuppPubInfo
     - keyDataLength: 128
-    - protected = << { / alg / 1: -29 / ECDH-ES+A128KW / } >>
-    - other = 'SUIT Payload Encryption'
+    - protected: { / alg / 1: -29 / ECDH-ES+A128KW / }
+    - other: 'SUIT Payload Encryption'
 
 The COSE_Encrypt structure, in hex format, is (with a line break inserted):
 
@@ -860,11 +860,11 @@ This example uses the following parameters:
   - d: h'60FE6DD6D85D5740A5349B6F91267EEAC5BA81B8CB53EE249E4B4EB102C476B3'
   - kid: 'kid-2'
 - KDF Context
-  - ALgorithm ID: -3 (A128KW)
+  - Algorithm ID: -65534 (A128CTR)
   - SuppPubInfo
     - keyDataLength: 128
-    - protected = << { / alg / 1: -3 / A128KW / } >>
-    - other = 'SUIT Payload Encryption'
+    - protected: { / alg / 1: -29 / ECDH-ES+A128KW / }
+    - other: 'SUIT Payload Encryption'
 
 The COSE_Encrypt structure, in hex format, is (with a line break inserted):
 
@@ -983,8 +983,8 @@ This example uses the following parameters:
   - Algorithm ID: -65531 (A128CBC)
   - SuppPubInfo
     - keyDataLength: 128
-    - protected = h''
-    - other = 'SUIT Payload Encryption'
+    - protected: { / alg / 1: -29 / ECDH-ES+A128KW / }
+    - other: 'SUIT Payload Encryption'
 
 The COSE_Encrypt structure, in hex format, is (with a line break inserted):
 

--- a/examples/generate_suit_encryption_info_aescbc_aesctr.py
+++ b/examples/generate_suit_encryption_info_aescbc_aesctr.py
@@ -89,15 +89,14 @@ kdf_context_a128cbc = {
     "alg": "A128CBC",
     "supp_pub": {
         "key_data_length": 128,
-        "protected": {},
+        "protected": {"alg": "ECDH-ES+A128KW"},
         "other": "SUIT Payload Encryption",
     }
 }
 
 # The sender side:
 r = Recipient.new(
-    protected={},
-    unprotected={"alg": "ECDH-ES+A128KW"},
+    protected={"alg": "ECDH-ES+A128KW"},
     sender_key=COSEKey.from_jwk(sender_private_key_jwk),
     recipient_key=COSEKey.from_jwk(receiver_public_key_jwk),
     context=kdf_context_a128cbc
@@ -216,15 +215,14 @@ kdf_context_a128ctr = {
     "alg": "A128CTR",
     "supp_pub": {
         "key_data_length": 128,
-        "protected": {},
+        "protected": {"alg": "ECDH-ES+A128KW"},
         "other": "SUIT Payload Encryption",
     }
 }
 
 # The sender side:
 r = Recipient.new(
-    protected={},
-    unprotected={"alg": "ECDH-ES+A128KW"},
+    protected={"alg": "ECDH-ES+A128KW"},
     sender_key=COSEKey.from_jwk(sender_private_key_jwk),
     recipient_key=COSEKey.from_jwk(receiver_public_key_jwk),
     context=kdf_context_a128ctr

--- a/examples/validate_esdh_non_aead_suit_encryption_info.py
+++ b/examples/validate_esdh_non_aead_suit_encryption_info.py
@@ -36,7 +36,7 @@ kdf_context = {
     "alg": kdf_algorithm,
     "supp_pub": {
         "key_data_length": 128,
-        "protected": {},
+        "protected": {"alg": "ECDH-ES+A128KW"},
         "other": "SUIT Payload Encryption",
     },
 }


### PR DESCRIPTION
ECDH-ES+A128KW (-29) should be placed in the protected field.  
A128CTR (-65534) is used for AlgorithmID.  

NOTE:   
This PR contains additional trivial fixes.  
There is no need to update example binaries, because the COSE library python-cwt internally fixes protected field.