### PR TITLE
Resolve Too long line warnings

### DIFF
--- a/cddls/aeskw.cddl
+++ b/cddls/aeskw.cddl
@@ -18,7 +18,7 @@ empty_map = {}
 
 recipient_header_unpr_map_aeskw =
 {
-    1 => int,         ; algorithm identifier
-  ? 4 => bstr,        ; identifier of the KEK pre-shared with the recipient
+    1 => int,     ; algorithm identifier
+  ? 4 => bstr,    ; identifier of the KEK pre-shared with the recipient
   * label => values   ; extension point
 }

--- a/draft-ietf-suit-firmware-encryption.md
+++ b/draft-ietf-suit-firmware-encryption.md
@@ -1052,7 +1052,7 @@ An example command sequence is shown in {{figure-image-match-after-decryption}}.
   / parameter-source-component / 22: 1
 },
 / directive-copy / 22, 15,
-/ condition-image-match / 3, 15 / integrity check on decrypted payload /,
+/ condition-image-match / 3, 15 / check decrypted payload integrity /,
 ~~~
 {: #figure-image-match-after-decryption title="Check Image Match After Decryption"}
 
@@ -1078,7 +1078,7 @@ This option mitigates battery exhaustion attacks discussed in {{sec-cons}}.
   / parameter-uri / 21: "http://example.com/encrypted.bin"
 },
 / directive-fetch / 21, 15,
-/ condition-image-match / 3, 15 / integrity check on encrypted payload /,
+/ condition-image-match / 3, 15 / check decrypted payload integrity /,
 
 / directive-set-component-index / 12, 0,
 / directive-override-parameters / 20, {
@@ -1346,12 +1346,12 @@ While parsing the manifest, the behavior of SUIT manifest processor would be
 - [L2-L17] authenticates the manifest part on [L18-L68]
 - [L22-L25] gets two component identifiers; ['plaintext-firmware'] for component #0, and ['encrypted-firmware'] for component # 1 respectively
 - [L29] sets current component index # 1 (the lasting directives target ['encrypted-firmware'])
-- [L33] sets source uri parameter "https://example.com/encrypted-firmware"
-- [L35] fetches content from source uri into ['encrypted-firmware']
-- [L38] sets current component index # 0 (the lasting directives target ['plaintext-firmware'])
-- [L41-L61] sets SUIT encryption info parameter
-- [L62] sets source component index parameter # 1
-- [L65] decrypts component # 1 (source component index) and stores the result into component # 0 (current component index)
+- [L33-L34] sets source uri parameter "https://example.com/encrypted-firmware"
+- [L36] fetches content from source uri into ['encrypted-firmware']
+- [L39] sets current component index # 0 (the lasting directives target ['plaintext-firmware'])
+- [L42-L62] sets SUIT encryption info parameter
+- [L63-L64] sets source component index parameter # 1
+- [L66] decrypts component # 1 (source component index) and stores the result into component # 0 (current component index)
 
 The following attributes and features from the SUIT manifest specification are used:
 

--- a/examples/suit-manifest-aes-kw-content.diag.signed
+++ b/examples/suit-manifest-aes-kw-content.diag.signed
@@ -45,7 +45,7 @@
 / 45/                 / kid / 4: 'kid-1'
 / 46/               },
 / 47/               / payload: /
-/ 48/                 h'75603FFC9518D794713C8CA8A115A7FB32565A6D59534D62'
+/ 48/               h'75603FFC9518D794713C8CA8A115A7FB32565A6D59534D62'
 / 49/                 / CEK encrypted with KEK /
 / 50/             ]
 / 51/           ]

--- a/examples/suit-manifest-aes-kw-slot.diag.signed
+++ b/examples/suit-manifest-aes-kw-slot.diag.signed
@@ -29,38 +29,39 @@
 / 29/       / directive-set-component-index / 12, 1 / [h'01'] /,
 / 30/       / directive-override-parameters / 20, {
 / 31/         / parameter-image-size / 14: 46,
-/ 32/         / parameter-uri / 21: "https://example.com/encrypted-firmware"
-/ 33/       },
-/ 34/       / directive-fetch / 21, 15,
-/ 35/ 
-/ 36/       / decrypt encrypted firmware /
-/ 37/       / directive-set-component-index / 12, 0 / ['00'] /,
-/ 38/       / directive-override-parameters / 20, {
-/ 39/         / parameter-encryption-info / 19: << 96([
-/ 40/           / protected: / << {
-/ 41/             / alg / 1: 1 / A128GCM /
-/ 42/           } >>,
-/ 43/           / unprotected: / {
-/ 44/             / IV / 5: h'F14AAB9D81D51F7AD943FE87'
-/ 45/           },
-/ 46/           / payload: / null / detached ciphertext /,
-/ 47/           / recipients: / [
-/ 48/             [
-/ 49/               / protected: / h'',
-/ 50/               / unprotected: / {
-/ 51/                 / alg / 1: -3 / A128KW /,
-/ 52/                 / kid / 4: 'kid-1'
-/ 53/               },
-/ 54/               / payload: /
-/ 55/                 h'75603FFC9518D794713C8CA8A115A7FB32565A6D59534D62'
-/ 56/                 / CEK encrypted with KEK /
-/ 57/             ]
-/ 58/           ]
-/ 59/         ]) >>,
-/ 60/         / parameter-source-component / 22: 1 / [h'01'] /
-/ 61/       },
-/ 62/       / directive-copy / 22, 15
-/ 63/         / consumes the SUIT_Encryption_Info above /
-/ 64/     ] >>
-/ 65/   } >>
-/ 66/ })
+/ 32/         / parameter-uri / 21:
+/ 33/           "https://example.com/encrypted-firmware"
+/ 34/       },
+/ 35/       / directive-fetch / 21, 15,
+/ 36/ 
+/ 37/       / decrypt encrypted firmware /
+/ 38/       / directive-set-component-index / 12, 0 / ['00'] /,
+/ 39/       / directive-override-parameters / 20, {
+/ 40/         / parameter-encryption-info / 19: << 96([
+/ 41/           / protected: / << {
+/ 42/             / alg / 1: 1 / A128GCM /
+/ 43/           } >>,
+/ 44/           / unprotected: / {
+/ 45/             / IV / 5: h'F14AAB9D81D51F7AD943FE87'
+/ 46/           },
+/ 47/           / payload: / null / detached ciphertext /,
+/ 48/           / recipients: / [
+/ 49/             [
+/ 50/               / protected: / h'',
+/ 51/               / unprotected: / {
+/ 52/                 / alg / 1: -3 / A128KW /,
+/ 53/                 / kid / 4: 'kid-1'
+/ 54/               },
+/ 55/               / payload: /
+/ 56/               h'75603FFC9518D794713C8CA8A115A7FB32565A6D59534D62'
+/ 57/                 / CEK encrypted with KEK /
+/ 58/             ]
+/ 59/           ]
+/ 60/         ]) >>,
+/ 61/         / parameter-source-component / 22: 1 / [h'01'] /
+/ 62/       },
+/ 63/       / directive-copy / 22, 15
+/ 64/         / consumes the SUIT_Encryption_Info above /
+/ 65/     ] >>
+/ 66/   } >>
+/ 67/ })

--- a/examples/suit-manifest-aes-kw.diag.signed
+++ b/examples/suit-manifest-aes-kw.diag.signed
@@ -30,40 +30,41 @@
 / 30/         / ['encrypted-firmware'] /,
 / 31/       / directive-override-parameters / 20, {
 / 32/         / parameter-image-size / 14: 46,
-/ 33/         / parameter-uri / 21: "https://example.com/encrypted-firmware"
-/ 34/       },
-/ 35/       / directive-fetch / 21, 15,
-/ 36/ 
-/ 37/       / decrypt encrypted firmware /
-/ 38/       / directive-set-component-index / 12, 0
-/ 39/         / ['plaintext-firmware'] /,
-/ 40/       / directive-override-parameters / 20, {
-/ 41/         / parameter-encryption-info / 19: << 96([
-/ 42/           / protected: / << {
-/ 43/             / alg / 1: 1 / A128GCM /
-/ 44/           } >>,
-/ 45/           / unprotected: / {
-/ 46/             / IV / 5: h'F14AAB9D81D51F7AD943FE87'
-/ 47/           },
-/ 48/           / payload: / null / detached ciphertext /,
-/ 49/           / recipients: / [
-/ 50/             [
-/ 51/               / protected: / h'',
-/ 52/               / unprotected: / {
-/ 53/                 / alg / 1: -3 / A128KW /,
-/ 54/                 / kid / 4: 'kid-1'
-/ 55/               },
-/ 56/               / payload: /
-/ 57/                 h'75603FFC9518D794713C8CA8A115A7FB32565A6D59534D62'
-/ 58/                 / CEK encrypted with KEK /
-/ 59/             ]
-/ 60/           ]
-/ 61/         ]) >>,
-/ 62/         / parameter-source-component / 22: 1
-/ 63/           / ['encrypted-firmware'] /
-/ 64/       },
-/ 65/       / directive-copy / 22, 15
-/ 66/         / consumes the SUIT_Encryption_Info above /
-/ 67/     ] >>
-/ 68/   } >>
-/ 69/ })
+/ 33/         / parameter-uri / 21:
+/ 34/           "https://example.com/encrypted-firmware"
+/ 35/       },
+/ 36/       / directive-fetch / 21, 15,
+/ 37/ 
+/ 38/       / decrypt encrypted firmware /
+/ 39/       / directive-set-component-index / 12, 0
+/ 40/         / ['plaintext-firmware'] /,
+/ 41/       / directive-override-parameters / 20, {
+/ 42/         / parameter-encryption-info / 19: << 96([
+/ 43/           / protected: / << {
+/ 44/             / alg / 1: 1 / A128GCM /
+/ 45/           } >>,
+/ 46/           / unprotected: / {
+/ 47/             / IV / 5: h'F14AAB9D81D51F7AD943FE87'
+/ 48/           },
+/ 49/           / payload: / null / detached ciphertext /,
+/ 50/           / recipients: / [
+/ 51/             [
+/ 52/               / protected: / h'',
+/ 53/               / unprotected: / {
+/ 54/                 / alg / 1: -3 / A128KW /,
+/ 55/                 / kid / 4: 'kid-1'
+/ 56/               },
+/ 57/               / payload: /
+/ 58/               h'75603FFC9518D794713C8CA8A115A7FB32565A6D59534D62'
+/ 59/                 / CEK encrypted with KEK /
+/ 60/             ]
+/ 61/           ]
+/ 62/         ]) >>,
+/ 63/         / parameter-source-component / 22: 1
+/ 64/           / ['encrypted-firmware'] /
+/ 65/       },
+/ 66/       / directive-copy / 22, 15
+/ 67/         / consumes the SUIT_Encryption_Info above /
+/ 68/     ] >>
+/ 69/   } >>
+/ 70/ })

--- a/examples/suit-manifest-es-ecdh-content.diag.signed
+++ b/examples/suit-manifest-es-ecdh-content.diag.signed
@@ -57,7 +57,7 @@
 / 57/                 / kid / 4: 'kid-2'
 / 58/               },
 / 59/               / payload: /
-/ 60/                 h'A06B8E6550F308712B1DF044B21B7D11D9B22792F1DE0997'
+/ 60/               h'A06B8E6550F308712B1DF044B21B7D11D9B22792F1DE0997'
 / 61/                 / CEK encrypted with KEK /
 / 62/             ]
 / 63/           ]

--- a/examples/suit-manifest-es-ecdh-dependency.diag.signed
+++ b/examples/suit-manifest-es-ecdh-dependency.diag.signed
@@ -68,7 +68,7 @@
 / 68/                 / kid / 4: 'kid-2'
 / 69/               },
 / 70/               / payload: /
-/ 71/                 h'A06B8E6550F308712B1DF044B21B7D11D9B22792F1DE0997'
+/ 71/               h'A06B8E6550F308712B1DF044B21B7D11D9B22792F1DE0997'
 / 72/                 / CEK encrypted with KEK /
 / 73/             ]
 / 74/           ]
@@ -125,28 +125,29 @@
 /125/             / directive-override-parameters / 20, {
 /126/               / parameter-image-digest / 3: << [
 /127/                 / algorithm-id / -16 / SHA256 /,
-/128/                 / digest-bytes / h'36921488FE6680712F734E11F58D87EE
-/129/                                    B66D4B21A8A1AD3441060814DA16D50F'
-/130/               ] >>,
-/131/               / parameter-image-size / 14: 30
-/132/             }
-/133/           ] >>
-/134/         } >>,
-/135/         / manifest-component-id / 5: [
-/136/           'dependency-manifest.suit'
-/137/         ],
-/138/         / validate / 7: << [
-/139/           / condition-image-match / 3, 15
-/140/         ] >>,
-/141/         / install / 20: << [
-/142/           / directive-set-component-index / 12, 0
-/143/             / ['decrypted-firmware'] /,
-/144/           / directive-write / 18, 15
-/145/             / consumes the SUIT_Encryption_Info set by dependent /,
-/146/           / condition-image-match / 3, 15
-/147/             / check the integrity of the decrypted payload /
-/148/         ] >>
-/149/       } >>
-/150/     })
-/151/   >>
-/152/ })
+/128/                 / digest-bytes /
+/129/                   h'36921488FE6680712F734E11F58D87EE
+/130/                     B66D4B21A8A1AD3441060814DA16D50F'
+/131/               ] >>,
+/132/               / parameter-image-size / 14: 30
+/133/             }
+/134/           ] >>
+/135/         } >>,
+/136/         / manifest-component-id / 5: [
+/137/           'dependency-manifest.suit'
+/138/         ],
+/139/         / validate / 7: << [
+/140/           / condition-image-match / 3, 15
+/141/         ] >>,
+/142/         / install / 20: << [
+/143/           / directive-set-component-index / 12, 0
+/144/             / ['decrypted-firmware'] /,
+/145/           / directive-write / 18, 15
+/146/             / consumes the SUIT_Encryption_Info in dependent /,
+/147/           / condition-image-match / 3, 15
+/148/             / check the integrity of the decrypted payload /
+/149/         ] >>
+/150/       } >>
+/151/     })
+/152/   >>
+/153/ })


### PR DESCRIPTION
Solves Martin Thomson's review
> Many of the CDDL or diagnostic output figures are wider than the 72 column format permits.

This PR updates some comments and removes some white spaces. Binaries are not affected.