### PR TITLE
Transform the Table 3 with kramdown style

### DIFF
--- a/draft-ietf-suit-firmware-encryption.md
+++ b/draft-ietf-suit-firmware-encryption.md
@@ -1486,35 +1486,11 @@ two methods are utilized, namely AES Key Wrap (AES-KW) and Ephemeral-Static
 Diffie-Hellman (ES-DH). In this table we summarize the main properties with
 respect to their deployment:
 
-~~~
-+---------------++------------+---------------+----------------+
-|               ||            |               |                |
-|  Number of    ||  Same key  |  One key      |  One Key       |
-|  Long-Term    ||  for all   |  per device   |  per device    |
-|  Keys         ||  devices   |               |                |
-|               ||            |               |                |
-+---------------++------------+---------------+----------------+
-|               ||            |               |                |
-|  Number of    ||  Single    |  Single       |  One CEK       |
-|  Content      ||  CEK per   |  CEK per      |  per payload   |
-|  Encryption   ||  payload   |  payload      |  encryption    |
-|  Keys (CEKs)  ||  shared    |  shared       |  transaction   |
-|               ||  with all  |  with all     |  per device    |
-|               ||  devies    |  devies       |                |
-|               ||            |               |                |
-+---------------++------------+---------------+----------------+
-|               ||            |               |                |
-|  Use Case     ||  Legacy    |  Efficient    |  Point-to-     |
-|               ||  Usage     |  Payload      |  Point Payload |
-|               ||            |  Distribution |  Distribution  |
-|               ||            |               |                |
-+---------------++------------+---------------+----------------+
-|               ||            |               |                |
-|  Recommended? ||  No, bad   |  Yes          |  Yes           |
-|               ||  practice  |               |                |
-|               ||            |               |                |
-+---------------++------------+---------------+----------------+
-~~~
+| Number of<br/>Long-Term<br/>Keys | Number of<br/>Content<br/>Encryption<br/>Keys (CEKs)                  | Use Case                                     | Recommended?         |
+|----------------------------------|-----------------------------------------------------------------------|----------------------------------------------|----------------------|
+| Same key<br/>for all<br/>devices | Single<br/>CEK per<br/>payload<br/>shared<br/>with all<br/>devies     | Legacy<br/>Usage                             | No, bad<br/>practice |
+| One key<br/>per device           | Single<br/>CEK per<br/>payload<br/>shared<br/>with all<br/>devies     | Efficient<br/>Payload<br/>Distribution       | Yes                  |
+| One Key<br/>per device           | One CEK<br/>per payload<br/>encryption<br/>transaction<br/>per device | Point-to-<br/>Point Payload<br/>Distribution | Yes                  |
 
 The use of firmware encryption with IoT devices introduces an battery
 exhaustion attack. This attack utilizes the fact that flash memory


### PR DESCRIPTION
Solves Martin Thomson's review comment
> Section 12 has a wonderful table that is drawn using ascii art, which is then converted to an SVG.  Please use a table.

I've transformed the Table 3 because the original one has header field at the first (left) column, but it is usual that it locates at the first (top) row.
Additionally, I've converted it to [kramdown style table](https://kramdown.gettalong.org/syntax.html#tables).

The Table 3 in html file will be
![image](https://github.com/user-attachments/assets/f739d736-83aa-44fe-9296-1773229a197b)

and one in txt file will be
```
         +===========+=============+==============+==============+
         | Number of | Number of   | Use Case     | Recommended? |
         | Long-Term | Content     |              |              |
         | Keys      | Encryption  |              |              |
         |           | Keys (CEKs) |              |              |
         +===========+=============+==============+==============+
         | Same key  | Single      | Legacy       | No, bad      |
         | for all   | CEK per     | Usage        | practice     |
         | devices   | payload     |              |              |
         |           | shared      |              |              |
         |           | with all    |              |              |
         |           | devies      |              |              |
         +-----------+-------------+--------------+--------------+
         | One key   | Single      | Efficient    | Yes          |
         | per       | CEK per     | Payload      |              |
         | device    | payload     | Distribution |              |
         |           | shared      |              |              |
         |           | with all    |              |              |
         |           | devies      |              |              |
         +-----------+-------------+--------------+--------------+
         | One Key   | One CEK     | Point-to-    | Yes          |
         | per       | per payload | Point        |              |
         | device    | encryption  | Payload      |              |
         |           | transaction | Distribution |              |
         |           | per device  |              |              |
         +-----------+-------------+--------------+--------------+

                                  Table 3
```