### PR TITLE
[EDITORIAL] Brushup xml sourcecode (sample cbor-diags)

### DIFF
--- a/draft-ietf-suit-firmware-encryption.md
+++ b/draft-ietf-suit-firmware-encryption.md
@@ -657,7 +657,7 @@ This example uses the following parameters:
 
 The COSE_Encrypt structure, in hex format, is (with a line break inserted):
 
-~~~
+~~~ test-vectors
 {::include-fold examples/suit-encryption-info-aes-kw-aes-gcm.hex}
 ~~~
 
@@ -671,7 +671,7 @@ The resulting COSE_Encrypt structure in a diagnostic format is shown in
 
 The encrypted payload (with a line feed added) was:
 
-~~~
+~~~ test-vectors
 {::include-fold examples/encrypted-payload-aes-kw-aes-gcm.hex}
 ~~~
 
@@ -696,7 +696,7 @@ This example uses the following parameters:
 
 The COSE_Encrypt structure, in hex format, is (with a line break inserted):
 
-~~~
+~~~ test-vectors
 {::include-fold examples/suit-encryption-info-es-ecdh-aes-gcm.hex}
 ~~~
 
@@ -710,7 +710,7 @@ The resulting COSE_Encrypt structure in a diagnostic format is shown in
 
 The encrypted payload (with a line feed added) was:
 
-~~~
+~~~ test-vectors
 {::include-fold examples/encrypted-payload-es-ecdh-aes-gcm.hex}
 ~~~
 
@@ -775,7 +775,7 @@ This example uses the following parameters:
 
 The COSE_Encrypt structure, in hex format, is (with a line break inserted):
 
-~~~
+~~~ test-vectors
 {::include-fold examples/suit-encryption-info-aes-kw-aes-ctr.hex}
 ~~~
 
@@ -789,7 +789,7 @@ The resulting COSE_Encrypt structure in a diagnostic format is shown in
 
 The encrypted payload (with a line feed added) was:
 
-~~~
+~~~ test-vectors
 {::include-fold examples/encrypted-payload-aes-kw-aes-ctr.hex}
 ~~~
 
@@ -814,7 +814,7 @@ This example uses the following parameters:
 
 The COSE_Encrypt structure, in hex format, is (with a line break inserted):
 
-~~~
+~~~ test-vectors
 {::include-fold examples/suit-encryption-info-es-ecdh-aes-ctr.hex}
 ~~~
 
@@ -828,7 +828,7 @@ The resulting COSE_Encrypt structure in a diagnostic format is shown in
 
 The encrypted payload (with a line feed added) was:
 
-~~~
+~~~ test-vectors
 {::include-fold examples/encrypted-payload-es-ecdh-aes-ctr.hex}
 ~~~
 
@@ -892,7 +892,7 @@ This example uses the following parameters:
 
 The COSE_Encrypt structure, in hex format, is (with a line break inserted):
 
-~~~
+~~~ test-vectors
 {::include-fold examples/suit-encryption-info-aes-kw-aes-cbc.hex}
 ~~~
 
@@ -906,7 +906,7 @@ The resulting COSE_Encrypt structure in a diagnostic format is shown in
 
 The encrypted payload (with a line feed added) was:
 
-~~~
+~~~ test-vectors
 {::include-fold examples/encrypted-payload-aes-kw-aes-cbc.hex}
 ~~~
 
@@ -931,7 +931,7 @@ This example uses the following parameters:
 
 The COSE_Encrypt structure, in hex format, is (with a line break inserted):
 
-~~~
+~~~ test-vectors
 {::include-fold examples/suit-encryption-info-es-ecdh-aes-cbc.hex}
 ~~~
 
@@ -945,7 +945,7 @@ The resulting COSE_Encrypt structure in a diagnostic format is shown in
 
 The encrypted payload (with a line feed added) was:
 
-~~~
+~~~ test-vectors
 {::include-fold examples/encrypted-payload-es-ecdh-aes-cbc.hex}
 ~~~
 
@@ -1245,7 +1245,7 @@ The SUIT manifest in diagnostic notation (with line breaks added for clarity) is
 
 In hex format, the SUIT manifest is:
 
-~~~
+~~~ test-vectors
 {::include-fold examples/suit-manifest-aes-kw-content.hex.signed}
 ~~~
 
@@ -1304,13 +1304,13 @@ The resulting state of SUIT manifest processor is shown in the following table:
 
 In hex format, the SUIT manifest shown above is:
 
-~~~
+~~~ test-vectors
 {::include-fold examples/suit-manifest-aes-kw.hex.signed}
 ~~~
 
 The encrypted payload (with a line feed added) to be fetched from "https://example.com/encrypted-firmware" is:
 
-~~~
+~~~ test-vectors
 {::include-fold examples/encrypted-payload-aes-kw-aes-gcm.hex}
 ~~~
 
@@ -1338,7 +1338,7 @@ is presented below:
 
 In hex format, the SUIT manifest is this:
 
-~~~
+~~~ test-vectors
 {::include-fold examples/suit-manifest-es-ecdh-content.hex.signed}
 ~~~
 
@@ -1368,7 +1368,7 @@ readability) is shown here:
 
 In hex format, the SUIT manifest is this:
 
-~~~
+~~~ test-vectors
 {::include-fold examples/suit-manifest-es-ecdh-dependency.hex.signed}
 ~~~
 

--- a/draft-ietf-suit-firmware-encryption.md
+++ b/draft-ietf-suit-firmware-encryption.md
@@ -1308,6 +1308,12 @@ In hex format, the SUIT manifest shown above is:
 {::include-fold examples/suit-manifest-aes-kw.hex.signed}
 ~~~
 
+The encrypted payload (with a line feed added) to be fetched from "https://example.com/encrypted-firmware" is:
+
+~~~
+{::include-fold examples/encrypted-payload-aes-kw-aes-gcm.hex}
+~~~
+
 The previous example does not utilize storage slots. However, it is possible to
 implement this functionality for devices that support slots in flash memory. In
 the enhanced example below, we reference the slots using [h'00'] and [h'01']. In

--- a/draft-ietf-suit-firmware-encryption.md
+++ b/draft-ietf-suit-firmware-encryption.md
@@ -240,7 +240,7 @@ the distribution system needs to know which method is supported. Limiting a
 constrained device to a single content key distribution method also helps
 reduce code size.
 
-~~~
+~~~ cddl
 SUIT_Parameters //= (suit-parameter-encryption-info
     => bstr .cbor SUIT_Encryption_Info)
 
@@ -302,6 +302,7 @@ payload will be stored into component #0.
   / parameter-uri / 21: "http://example.com/encrypted.bin",
 },
 / directive-fetch / 21, 15,
+
 / directive-set-component-index / 12, 0,
 / directive-override-parameters / 20, {
   / parameter-encryption-info / TBD19: h'D86...1F0',
@@ -437,12 +438,12 @@ unique CEKs. The sender needs to execute the following steps:
     2.  }
 ~~~
 
-### CDDL
+### The CDDL of SUIT_Encryption_Info for AES-KW binary
 
 The CDDL for the AES-KW binary is shown in {{cddl-aeskw}}.
 empty_or_serialized_map and header_map are structures defined in {{RFC9052}}.
 
-~~~
+~~~ cddl
 {::include-fold cddls/aeskw.cddl}
 ~~~
 {: #cddl-aeskw title="CDDL for AES-KW-based Content Key Distribution"}
@@ -519,13 +520,13 @@ The sender must then follow these steps:
         }
 ~~~
 
-### CDDL
+### The CDDL of SUIT_Encryption_Info for ES-DH binary
 
 The CDDL for the ECDH-ES+AES-KW binary is provided in {{cddl-esdh}}.
 Only the essential parameters are included. The structures empty_or_serialized_map
 and header_map are defined in {{RFC9052}}.
 
-~~~
+~~~ cddl
 {::include-fold cddls/esdh_aeskw.cddl}
 ~~~
 {: #cddl-esdh title="CDDL for ES-DH-based Content Key Distribution"}
@@ -566,7 +567,7 @@ the constant string "SUIT Payload Encryption".
 content of the recipient_header_map_esdh field, which contains (among other
 elements) the identifier of the content key distribution method.
 
-~~~ CDDL
+~~~ cddl
 {::include-fold cddls/kdf-context.cddl}
 ~~~
 {: #cddl-context-info title="CDDL for COSE_KDF_Context Structure"}
@@ -596,7 +597,7 @@ COSE specification requires a consistent byte stream to create the
 authenticated data structure. This structure is illustrated in
 {{cddl-enc-aeskw}} and defined in {{Section 5.3 of RFC9052}}.
 
-~~~
+~~~ cddl
  Enc_structure = [
    context : "Encrypt",
    protected : empty_or_serialized_map,
@@ -663,7 +664,7 @@ The COSE_Encrypt structure, in hex format, is (with a line break inserted):
 The resulting COSE_Encrypt structure in a diagnostic format is shown in
 {{aeskw-aesgcm-example}}.
 
-~~~
+~~~ cbor-diag
 {::include-fold examples/suit-encryption-info-aes-kw-aes-gcm.diag}
 ~~~
 {: #aeskw-aesgcm-example title="COSE_Encrypt Example for AES Key Wrap"}
@@ -702,7 +703,7 @@ The COSE_Encrypt structure, in hex format, is (with a line break inserted):
 The resulting COSE_Encrypt structure in a diagnostic format is shown in
 {{esdh-aesgcm-example}}.
 
-~~~
+~~~ cbor-diag
 {::include-fold examples/suit-encryption-info-es-ecdh-aes-gcm.diag}
 ~~~
 {: #esdh-aesgcm-example title="COSE_Encrypt Example for ES-DH"}
@@ -781,7 +782,7 @@ The COSE_Encrypt structure, in hex format, is (with a line break inserted):
 The resulting COSE_Encrypt structure in a diagnostic format is shown in
 {{aeskw-aesctr-example}}.
 
-~~~
+~~~ cbor-diag
 {::include-fold examples/suit-encryption-info-aes-kw-aes-ctr.diag}
 ~~~
 {: #aeskw-aesctr-example title="COSE_Encrypt Example for AES Key Wrap"}
@@ -820,7 +821,7 @@ The COSE_Encrypt structure, in hex format, is (with a line break inserted):
 The resulting COSE_Encrypt structure in a diagnostic format is shown in
 {{esdh-aesctr-example}}.
 
-~~~
+~~~ cbor-diag
 {::include-fold examples/suit-encryption-info-es-ecdh-aes-ctr.diag}
 ~~~
 {: #esdh-aesctr-example title="COSE_Encrypt Example for ES-DH"}
@@ -898,7 +899,7 @@ The COSE_Encrypt structure, in hex format, is (with a line break inserted):
 The resulting COSE_Encrypt structure in a diagnostic format is shown in
 {{aeskw-aescbc-example}}.
 
-~~~
+~~~ cbor-diag
 {::include-fold examples/suit-encryption-info-aes-kw-aes-cbc.diag}
 ~~~
 {: #aeskw-aescbc-example title="COSE_Encrypt Example for AES Key Wrap"}
@@ -937,7 +938,7 @@ The COSE_Encrypt structure, in hex format, is (with a line break inserted):
 The resulting COSE_Encrypt structure in a diagnostic format is shown in
 {{esdh-aescbc-example}}.
 
-~~~
+~~~ cbor-diag
 {::include-fold examples/suit-encryption-info-es-ecdh-aes-cbc.diag}
 ~~~
 {: #esdh-aescbc-example title="COSE_Encrypt Example for ES-DH"}
@@ -985,7 +986,7 @@ An example command sequence is shown in {{figure-image-match-after-decryption}}.
   / parameter-source-component / 22: 1
 },
 / directive-copy / 22, 15,
-/ condition-image-match / 3, 15 / check decrypted payload integrity /,
+/ condition-image-match / 3, 15 / check decrypted payload integrity /
 ~~~
 {: #figure-image-match-after-decryption title="Check Image Match After Decryption"}
 
@@ -1010,6 +1011,7 @@ This option mitigates battery exhaustion attacks discussed in {{sec-cons}}.
   / parameter-image-size / 14: 30 / size of encrypted payload /,
   / parameter-uri / 21: "http://example.com/encrypted.bin"
 },
+
 / directive-fetch / 21, 15,
 / condition-image-match / 3, 15 / check decrypted payload integrity /,
 
@@ -1018,7 +1020,7 @@ This option mitigates battery exhaustion attacks discussed in {{sec-cons}}.
   / parameter-encryption-info / TBD19: h'D86...1F0',
   / parameter-source-component / 22: 1
 },
-/ directive-copy / 22, 15,
+/ directive-copy / 22, 15
 ~~~
 {: #figure-image-match-before-decryption title="Check Image Match Before Decryption"}
 
@@ -1237,7 +1239,7 @@ the encrypted payload into a component using the suit-directive-write directive.
 
 The SUIT manifest in diagnostic notation (with line breaks added for clarity) is displayed below:
 
-~~~
+~~~ cbor-diag
 {::include-fold examples/suit-manifest-aes-kw-content.diag.signed}
 ~~~
 
@@ -1259,7 +1261,7 @@ is particularly effective for constrained devices with execute-in-place
 The SUIT manifest in diagnostic notation (with line breaks added for
 clarity) is displayed below:
 
-~~~
+~~~ cbor-diag
 {::include-fold examples/suit-manifest-aes-kw.diag.signed}
 ~~~
 
@@ -1311,7 +1313,7 @@ implement this functionality for devices that support slots in flash memory. In
 the enhanced example below, we reference the slots using [h'00'] and [h'01']. In
 this context, the component identifier [h'00'] designates component slot #0.
 
-~~~
+~~~ cbor-diag
 {::include-fold examples/suit-manifest-aes-kw-slot.diag.signed}
 ~~~
 
@@ -1324,7 +1326,7 @@ the encrypted payload into a component via the suit-directive-write directive.
 The SUIT manifest in diagnostic notation (formatted with line breaks for clarity)
 is presented below:
 
-~~~
+~~~ cbor-diag
 {::include-fold examples/suit-manifest-es-ecdh-content.diag.signed}
 ~~~
 
@@ -1354,7 +1356,7 @@ and referred to by the "#dependency-manifest" URI.
 The SUIT manifest in diagnostic notation (with line breaks added for
 readability) is shown here:
 
-~~~
+~~~ cbor-diag
 {::include-fold examples/suit-manifest-es-ecdh-dependency.diag.signed}
 ~~~
 
@@ -1461,7 +1463,7 @@ parameter is set to 19, as the proposed value.
 The following CDDL must be appended to the SUIT Manifest CDDL. The SUIT CDDL is defined in
 Appendix A of {{I-D.ietf-suit-manifest}}
 
-~~~ CDDL
+~~~ cddl
 {::include-fold draft-ietf-suit-firmware-encryption.cddl}
 ~~~
 


### PR DESCRIPTION
- Updated the title of `CDDL` to `The CDDL of SUIT_Encryption_Info for <alg>`
- Added the to be fetched encrypted payload for AES-GCM; it is redundant but for better readability
- Added language annotation `cddl`, `cbor-diag` and `test-vectors` for code blocks to specifying `<sourcecode type="foo">` in xml
  - They are come from https://www.rfc-editor.org/rpc/wiki/doku.php?id=sourcecode-types
- Removed comma at the tail of cbor-diag part (yet they are not complete cbor-diag)