### PR TITLE
Clarifying that the protected headers are bstr wrapped

### DIFF
--- a/draft-ietf-suit-firmware-encryption.md
+++ b/draft-ietf-suit-firmware-encryption.md
@@ -701,7 +701,7 @@ This example uses the following parameters:
   - Algorithm ID: -3 (A128KW)
   - SuppPubInfo
     - keyDataLength: 128
-    - protected: { / alg / 1: -29 / ECDH-ES+A128KW / }
+    - protected: << { / alg / 1: -29 / ECDH-ES+A128KW / } >>
     - other: 'SUIT Payload Encryption'
 
 The COSE_Encrypt structure, in hex format, is (with a line break inserted):
@@ -815,7 +815,7 @@ This example uses the following parameters:
   - Algorithm ID: -3 (A128KW)
   - SuppPubInfo
     - keyDataLength: 128
-    - protected: { / alg / 1: -29 / ECDH-ES+A128KW / }
+    - protected: << { / alg / 1: -29 / ECDH-ES+A128KW / } >>
     - other: 'SUIT Payload Encryption'
 
 The COSE_Encrypt structure, in hex format, is (with a line break inserted):
@@ -932,7 +932,7 @@ This example uses the following parameters:
   - Algorithm ID: -3 (A128KW)
   - SuppPubInfo
     - keyDataLength: 128
-    - protected: { / alg / 1: -29 / ECDH-ES+A128KW / }
+    - protected: << { / alg / 1: -29 / ECDH-ES+A128KW / } >>
     - other: 'SUIT Payload Encryption'
 
 The COSE_Encrypt structure, in hex format, is (with a line break inserted):

--- a/examples/a128kw_kdf_context.diag
+++ b/examples/a128kw_kdf_context.diag
@@ -4,7 +4,7 @@
     / PartyVInfo: / [ null, null, null ],
     / SuppPubInfo: / [
         / keyDataLength: / 128,
-        / protected: / << { / alg / 1: -3 / A128KW / } >>,
+        / protected: / << { / alg / 1: -29 / ECDH-ES+A128KW / } >>,
         / other: / 'SUIT Payload Encryption'
     ]
 ]


### PR DESCRIPTION
Solves #71 by clarifying that the protected headers of ECDH-ES+A128KW examples are bstr wrapped.
See `examples/a128kw_kdf_context.diag` (which contained another bug and fixed in this PR).

## References
RFC 9053 defines
```
COSE_KDF_Context = [
    AlgorithmID : int / tstr,
    PartyUInfo : [ PartyInfo ],
    PartyVInfo : [ PartyInfo ],
    SuppPubInfo : [
        keyDataLength : uint,
        protected : empty_or_serialized_map,
        ? other : bstr
    ],
    ? SuppPrivInfo : bstr
]
```
and RFC 9052 defines
```
empty_or_serialized_map = bstr .cbor header_map / bstr .size 0
```

