### PR TITLE
Update Security Considerations to prevent some attacks

### DIFF
--- a/draft-ietf-suit-firmware-encryption.md
+++ b/draft-ietf-suit-firmware-encryption.md
@@ -1457,38 +1457,31 @@ enables the device to detect a battery exhaustion attack before
 energy-consuming decryption and flash memory copy or swap
 operations take place.
 
-As stated in {{Section 8 of RFC9459}}, implementers of recipients should perform
-integrity checks prior to decryption to avoid padding oracle vulnerabilities
-especially with AES-CBC mode.
-Such a check prevents them from being not only padding oracles
-but also format oracles and decryption oracles,
-because they don't perform decryption if the check fails.
-See {{payload-integrity-validation}}
-for more discussion about payload integrity validation.
+As specified in {{Section 8 of RFC9459}}, recipients must perform
+integrity checks before decryption to mitigate padding oracle
+vulnerabilities, particularly when using AES-CBC mode. This practice
+not only prevents padding oracle attacks but also protects against
+format and decryption oracles, as decryption is skipped if the
+integrity check fails. For further details on payload integrity
+validation, see {{payload-integrity-validation}}.
 
-The same IV and AES key combination MUST NOT be used more than once.
-This requirement applies not only to AES-CTR mode, as stated in {{Section 4 of RFC9459}},
+The same combination of IV and AES key MUST NOT be reused. This
+requirement applies not only to AES-CTR mode, as specified in
+{{Section 4 of RFC9459}}, but also to other content encryption
+algorithms, including AEAD ciphers like AES-GCM.
 
-but also to other content encryption algorithms,
-including AEAD ciphers such as AES-GCM.
-Even though AEAD ciphers provide authentication and integrity for payloads,
-both ENC(plaintext1, IV1, k1) and ENC(plaintext2, IV1, k1) are
-correctly decrypted and authenticated with the same decryption key.
-Consequently, recipients will also accept other AEAD ciphertexts
-with the same IV and AES key combination.
+Although the examples in this document use the coaps scheme for
+payload retrieval, alternative URI schemes like coap and http
+can also be used. This flexibility is possible because the SUIT
+manifest and this extension do not rely on the TLS layer for security.
 
-While the examples in this document use the coaps scheme for payload
-retrieval, alternative URI schemes such as coap and http may also
-be used. This flexibility is possible because the SUIT manifest
-and this extension are not dependent on the TLS layer for security.
-
-Confidentiality, integrity, and authentication are instead ensured
-through the SUIT manifest and the extensions defined in this document.
-See {{Section 12 of I-D.ietf-suit-manifest}} for how the SUIT manifest
-fullfills the security requirements outlined in {{RFC9124}}.
-See {{Section 11 of RFC9053}} and {{Section 8 of RFC9459}}
-for more security considerations of primitive cryptographic algorithms
-used in the extensions.
+Confidentiality, integrity, and authentication are ensured by the
+SUIT manifest and the extensions defined in this document. For
+details on how the SUIT manifest meets the security requirements
+outlined in {{RFC9124}}, refer to {{Section 12 of I-D.ietf-suit-manifest}}.
+Additional security considerations for the cryptographic primitives used
+in these extensions are discussed in {{Section 11 of RFC9053}} and
+{{Section 8 of RFC9459}}.
 
 #  IANA Considerations
 

--- a/draft-ietf-suit-firmware-encryption.md
+++ b/draft-ietf-suit-firmware-encryption.md
@@ -1471,6 +1471,11 @@ and this extension are not dependent on the TLS layer for security.
 
 Confidentiality, integrity, and authentication are instead ensured
 through the SUIT manifest and the extensions defined in this document.
+See {{Section 12 of I-D.ietf-suit-manifest}} for how the SUIT manifest
+fullfills the security requirements outlined in {{RFC9124}}.
+See {{Section 11 of RFC9053}} and {{Section 8 of RFC9459}}
+for more security considerations of primitive cryptographic algorithms
+used in the extensions.
 
 #  IANA Considerations
 

--- a/draft-ietf-suit-firmware-encryption.md
+++ b/draft-ietf-suit-firmware-encryption.md
@@ -1457,6 +1457,13 @@ enables the device to detect a battery exhaustion attack before
 energy-consuming decryption and flash memory copy or swap
 operations take place.
 
+As stated in {{Section 8 of RFC9459}}, implementers of recipients should perform
+integrity checks prior to decryption to avoid padding oracle vulnerabilities
+especially with AES-CBC mode.
+Such a check prevents them from being not only padding oracles
+but also format oracles and decryption oracles,
+because they don't perform decryption if the check fails.
+
 While the examples in this document use the coaps scheme for payload
 retrieval, alternative URI schemes such as coap and http may also
 be used. This flexibility is possible because the SUIT manifest

--- a/draft-ietf-suit-firmware-encryption.md
+++ b/draft-ietf-suit-firmware-encryption.md
@@ -1467,7 +1467,8 @@ See {{payload-integrity-validation}}
 for more discussion about payload integrity validation.
 
 The same IV and AES key combination MUST NOT be used more than once.
-This requirement applies not only to AES-CTR mode as stated in {{Section 4 of RFC9459}}
+This requirement applies not only to AES-CTR mode, as stated in {{Section 4 of RFC9459}},
+
 but also to other content encryption algorithms,
 including AEAD ciphers such as AES-GCM.
 Even though AEAD ciphers provide authentication and integrity for payloads,

--- a/draft-ietf-suit-firmware-encryption.md
+++ b/draft-ietf-suit-firmware-encryption.md
@@ -1466,6 +1466,16 @@ because they don't perform decryption if the check fails.
 See {{payload-integrity-validation}}
 for more discussion about payload integrity validation.
 
+The same IV and AES key combination MUST NOT be used more than once.
+This requirement applies not only to AES-CTR mode as stated in {{Section 4 of RFC9459}}
+but also to other content encryption algorithms,
+including AEAD ciphers such as AES-GCM.
+Even though AEAD ciphers provide authentication and integrity for payloads,
+both ENC(plaintext1, IV1, k1) and ENC(plaintext2, IV1, k1) are
+correctly decrypted and authenticated with the same decryption key.
+Consequently, recipients will also accept other AEAD ciphertexts
+with the same IV and AES key combination.
+
 While the examples in this document use the coaps scheme for payload
 retrieval, alternative URI schemes such as coap and http may also
 be used. This flexibility is possible because the SUIT manifest

--- a/draft-ietf-suit-firmware-encryption.md
+++ b/draft-ietf-suit-firmware-encryption.md
@@ -1038,7 +1038,7 @@ parameter is set to 19, as the proposed value.
 AEAD algorithms, such as AES-GCM and ChaCha20/Poly1305, verify the integrity of
 the encrypted concent.
 
-## Payload Integrity Validation
+## Payload Integrity Validation {#payload-integrity-validation}
 
 This subsection offers guidelines for validating the integrity of payloads within
 the SUIT manifest. The decision tree in {{payload-integrity-decision-tree}}
@@ -1463,6 +1463,8 @@ especially with AES-CBC mode.
 Such a check prevents them from being not only padding oracles
 but also format oracles and decryption oracles,
 because they don't perform decryption if the check fails.
+See {{payload-integrity-validation}}
+for more discussion about payload integrity validation.
 
 While the examples in this document use the coaps scheme for payload
 retrieval, alternative URI schemes such as coap and http may also


### PR DESCRIPTION
Solves #52 .
The paragraph does not explain the details of these attacks, but rather how they are prevented by the integrity check.
Also navigation to the security considerations of depending documents are added.